### PR TITLE
Fix repeating devices

### DIFF
--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -24,13 +24,16 @@ type LinuxCapabilities struct {
 }
 
 type LinuxDevice struct {
-	*specsgo.LinuxDevice
+	Path  string
+	Type  string
+	Major int64
+	Minor int64
 }
 
 type Report struct {
 	Runtime        string
-	Namespace      string
 	ID             string
+	Namespace      string
 	Image          string
 	PID            int
 	HostNamespaces Namespaces
@@ -40,5 +43,5 @@ type Report struct {
 	CgroupsPath    string
 	Status         string
 	Capabilities   *LinuxCapabilities
-	Devices        []*LinuxDevice
+	Devices        []LinuxDevice
 }

--- a/internal/audit/zap_marshal.go
+++ b/internal/audit/zap_marshal.go
@@ -65,7 +65,7 @@ func (r *Report) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 	enc.AddArray("devices", zapcore.ArrayMarshalerFunc(func(e zapcore.ArrayEncoder) error {
 		for _, device := range r.Devices {
-			e.AppendObject(device)
+			e.AppendObject(&device)
 		}
 		return nil
 	}))

--- a/internal/runtimes/containerd/auditor.go
+++ b/internal/runtimes/containerd/auditor.go
@@ -107,9 +107,14 @@ func (a *Auditor) auditContainer(namespace string, container containerd.Containe
 		return fmt.Errorf("error getting network info: %v", err)
 	}
 
-	devices := make([]*audit.LinuxDevice, len(spec.Linux.Devices))
+	devices := make([]audit.LinuxDevice, len(spec.Linux.Devices))
 	for i, dev := range spec.Linux.Devices {
-		devices[i] = &audit.LinuxDevice{LinuxDevice: &dev}
+		devices[i] = audit.LinuxDevice{
+			Path:  dev.Path,
+			Type:  dev.Type,
+			Major: dev.Major,
+			Minor: dev.Minor,
+		}
 	}
 
 	r := audit.Report{


### PR DESCRIPTION
This PR fixes the issue that reported devices seem to get repeated. Because they are pointers to some looped var, the first (or last) is populating all of the entries.