### PR TITLE
chore: speed up builds by cross-compiling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,8 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: tag
     steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17 as builder
 RUN mkdir /workdir
 WORKDIR /workdir
 COPY . /workdir
-RUN CGO_ENABLED=0 go build -o app -v main.go
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o app -v main.go
 
 FROM scratch
 COPY --from=builder /workdir/app /app


### PR DESCRIPTION
Previously, we relied on qemu to build foreign binaries. Since scra is written in Go and the compiler can cross build way faster than qemu does "natively", we could do better.

Inspired by [stackoverflow](https://stackoverflow.com/a/71374582) and [docker.com](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/)