### PR TITLE
fix: subsribe to tasks/start instead of containers/create

### DIFF
--- a/internal/runtimes/containerd/auditor.go
+++ b/internal/runtimes/containerd/auditor.go
@@ -69,6 +69,7 @@ func (a *Auditor) auditContainer(namespace string, container containerd.Containe
 
 	task, err := container.Task(ctx, nil)
 	if err != nil {
+		a.logger.Info("received an error retrieving task", zap.Error(err))
 		task = nil // non running tasks error, apparantly. Flag with nil task
 	}
 

--- a/internal/runtimes/containerd/watch.go
+++ b/internal/runtimes/containerd/watch.go
@@ -13,8 +13,8 @@ import (
 
 func (a *Auditor) Watch() error {
 	ctx := context.Background()
-	eventStream, errC := a.containerdClient.client.EventService().Subscribe(ctx, `topic=="/containers/create"`)
-	a.logger.Info("listening for containers/create events")
+	eventStream, errC := a.containerdClient.client.EventService().Subscribe(ctx, `topic=="/tasks/start"`)
+	a.logger.Info("listening for tasks/start events")
 	for {
 		var (
 			event *events.Envelope
@@ -39,10 +39,10 @@ func (a *Auditor) Watch() error {
 			}
 
 			switch t := e.(type) {
-			case *apievents.ContainerCreate:
+			case *apievents.TaskStart:
 				nsCtx := namespaces.WithNamespace(ctx, event.Namespace)
 
-				container, err := a.containerdClient.client.LoadContainer(nsCtx, t.ID)
+				container, err := a.containerdClient.client.LoadContainer(nsCtx, t.ContainerID)
 				if err != nil {
 					a.logger.Warn("error getting container details", zap.Error(err))
 					continue


### PR DESCRIPTION
This makes it possible to retrieve run time information, such as PID. Fixes #6. We assume the fact that we have proper task info outweighs the fact that unstarted containers become invisible.

Signed-off-by: Jorik Jonker <jorik.jonker@eu.equinix.com>