### PR TITLE
Couple of fixes to make scra run more pleasurable on Flatcar Linux

### DIFF
--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+func getLogger() (*zap.Logger, error) {
+	config := zap.NewProductionConfig()
+	if viper.GetBool("debug") {
+		config.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	}
+
+	return config.Build()
+}

--- a/cmd/once.go
+++ b/cmd/once.go
@@ -23,6 +23,11 @@ func init() {
 }
 
 func once(cmd *cobra.Command, args []string) {
+	logger, err := getLogger()
+	if err != nil {
+		panic(fmt.Errorf("error setting up zap logging: %v", err))
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -30,7 +35,7 @@ func once(cmd *cobra.Command, args []string) {
 	rootPrefix := viper.GetString("root-prefix")
 
 	for _, address := range viper.GetStringSlice("containerd-address") {
-		a, err := containerd.NewAuditor(address, rootPrefix, gctx)
+		a, err := containerd.NewAuditor(address, rootPrefix, gctx, logger)
 		if err != nil {
 			panic(err)
 		}
@@ -45,7 +50,7 @@ func once(cmd *cobra.Command, args []string) {
 		})
 	}
 
-	err := group.Wait()
+	err = group.Wait()
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ func init() {
 	flags := rootCmd.PersistentFlags()
 	flags.StringSlice("containerd-address", []string{"/run/containerd/containerd.sock"}, "location of containerd endpoint")
 	flags.String("root-prefix", "", "root prefix when accessing /proc et al from a hostPath mount")
+	flags.Bool("debug", false, "increase verbosity")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(err)

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -23,6 +23,11 @@ func init() {
 }
 
 func watch(cmd *cobra.Command, args []string) {
+	logger, err := getLogger()
+	if err != nil {
+		panic(fmt.Errorf("error setting up zap logging: %v", err))
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -30,7 +35,7 @@ func watch(cmd *cobra.Command, args []string) {
 	rootPrefix := viper.GetString("root-prefix")
 
 	for _, address := range viper.GetStringSlice("containerd-address") {
-		a, err := containerd.NewAuditor(address, rootPrefix, gctx)
+		a, err := containerd.NewAuditor(address, rootPrefix, gctx, logger)
 		if err != nil {
 			panic(err)
 		}
@@ -46,7 +51,7 @@ func watch(cmd *cobra.Command, args []string) {
 
 	}
 
-	err := group.Wait()
+	err = group.Wait()
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	}

--- a/internal/runtimes/containerd/auditor.go
+++ b/internal/runtimes/containerd/auditor.go
@@ -19,15 +19,10 @@ type Auditor struct {
 	context          context.Context
 }
 
-func NewAuditor(address string, prefix string, ctx context.Context) (*Auditor, error) {
+func NewAuditor(address string, prefix string, ctx context.Context, logger *zap.Logger) (*Auditor, error) {
 	client, err := NewClient(address, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %v", err)
-	}
-
-	logger, err := zap.NewProduction()
-	if err != nil {
-		return nil, fmt.Errorf("error setting up zap logging: %v", err)
 	}
 
 	a := &Auditor{

--- a/internal/runtimes/containerd/auditor.go
+++ b/internal/runtimes/containerd/auditor.go
@@ -73,7 +73,7 @@ func (a *Auditor) auditContainer(namespace string, container containerd.Containe
 
 	task, err := container.Task(ctx, nil)
 	if err != nil {
-		a.logger.Info("received an error retrieving task", zap.Error(err))
+		a.logger.Debug("received an error retrieving task", zap.Error(err))
 		task = nil // non running tasks error, apparantly. Flag with nil task
 	}
 
@@ -89,7 +89,7 @@ func (a *Auditor) auditContainer(namespace string, container containerd.Containe
 
 	image, err := container.Image(ctx)
 	if err != nil {
-		a.logger.Info("received an error retrieving image", zap.Error(err))
+		a.logger.Debug("received an error retrieving image", zap.Error(err))
 		image = nil
 	}
 


### PR DESCRIPTION
This branch was created to fix all the things needed to run scra on FL Linux. It turned out that it worked great out of the box, albeit with a bit over-verbose logging about containers not being originated from imaghes. So the logging are the only things fixed.