### PR TITLE
Add CodeQL analyzer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,20 @@ jobs:
         go-version: '1.17'
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
+  codeql:
+    name: analyze
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: go
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
   build-containers:
     name: build container test
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,9 @@ jobs:
   build-containers:
     name: build container test
     runs-on: ubuntu-latest
+    needs:
+    - golangci
+    - codeql
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -43,6 +46,9 @@ jobs:
   build-binaries:
     name: build test
     runs-on: ubuntu-latest
+    needs:
+    - golangci
+    - codeql
     strategy:
       matrix:
         goos: [linux]


### PR DESCRIPTION
We do not want to (accidentally) rely on external modules that have known vulnerabilities in them. CodeQL is one tool to help us with that.

Additionally, do not try to test-build binaries and containers unless the linter as well as CodeQL are happy with the code. This is not structly necessary but it save lots of cpu cycles at GitHub.